### PR TITLE
restore CRD location labelling

### DIFF
--- a/crd/k8c.io/apps.kubermatic.k8c.io_applicationdefinitions.yaml
+++ b/crd/k8c.io/apps.kubermatic.k8c.io_applicationdefinitions.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.10.0
+    kubermatic.k8c.io/location: master,seed
   name: applicationdefinitions.apps.kubermatic.k8c.io
 spec:
   group: apps.kubermatic.k8c.io

--- a/crd/k8c.io/apps.kubermatic.k8c.io_applicationinstallations.yaml
+++ b/crd/k8c.io/apps.kubermatic.k8c.io_applicationinstallations.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.10.0
+    kubermatic.k8c.io/location: usercluster
   name: applicationinstallations.apps.kubermatic.k8c.io
 spec:
   group: apps.kubermatic.k8c.io

--- a/crd/k8c.io/kubermatic.k8c.io_addonconfigs.yaml
+++ b/crd/k8c.io/kubermatic.k8c.io_addonconfigs.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.10.0
+    kubermatic.k8c.io/location: master
   name: addonconfigs.kubermatic.k8c.io
 spec:
   group: kubermatic.k8c.io

--- a/crd/k8c.io/kubermatic.k8c.io_addons.yaml
+++ b/crd/k8c.io/kubermatic.k8c.io_addons.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.10.0
+    kubermatic.k8c.io/location: seed
   name: addons.kubermatic.k8c.io
 spec:
   group: kubermatic.k8c.io

--- a/crd/k8c.io/kubermatic.k8c.io_admissionplugins.yaml
+++ b/crd/k8c.io/kubermatic.k8c.io_admissionplugins.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.10.0
+    kubermatic.k8c.io/location: master
   name: admissionplugins.kubermatic.k8c.io
 spec:
   group: kubermatic.k8c.io

--- a/crd/k8c.io/kubermatic.k8c.io_alertmanagers.yaml
+++ b/crd/k8c.io/kubermatic.k8c.io_alertmanagers.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.10.0
+    kubermatic.k8c.io/location: seed
   name: alertmanagers.kubermatic.k8c.io
 spec:
   group: kubermatic.k8c.io

--- a/crd/k8c.io/kubermatic.k8c.io_allowedregistries.yaml
+++ b/crd/k8c.io/kubermatic.k8c.io_allowedregistries.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.10.0
+    kubermatic.k8c.io/location: master
   name: allowedregistries.kubermatic.k8c.io
 spec:
   group: kubermatic.k8c.io

--- a/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
+++ b/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.10.0
+    kubermatic.k8c.io/location: seed
   name: clusters.kubermatic.k8c.io
 spec:
   group: kubermatic.k8c.io

--- a/crd/k8c.io/kubermatic.k8c.io_clustertemplateinstances.yaml
+++ b/crd/k8c.io/kubermatic.k8c.io_clustertemplateinstances.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.10.0
+    kubermatic.k8c.io/location: seed
   name: clustertemplateinstances.kubermatic.k8c.io
 spec:
   group: kubermatic.k8c.io

--- a/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
+++ b/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.10.0
+    kubermatic.k8c.io/location: master,seed
   name: clustertemplates.kubermatic.k8c.io
 spec:
   group: kubermatic.k8c.io

--- a/crd/k8c.io/kubermatic.k8c.io_constraints.yaml
+++ b/crd/k8c.io/kubermatic.k8c.io_constraints.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.10.0
+    kubermatic.k8c.io/location: master,seed
   name: constraints.kubermatic.k8c.io
 spec:
   group: kubermatic.k8c.io

--- a/crd/k8c.io/kubermatic.k8c.io_constrainttemplates.yaml
+++ b/crd/k8c.io/kubermatic.k8c.io_constrainttemplates.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.10.0
+    kubermatic.k8c.io/location: master,seed
   name: constrainttemplates.kubermatic.k8c.io
 spec:
   group: kubermatic.k8c.io

--- a/crd/k8c.io/kubermatic.k8c.io_etcdbackupconfigs.yaml
+++ b/crd/k8c.io/kubermatic.k8c.io_etcdbackupconfigs.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.10.0
+    kubermatic.k8c.io/location: seed
   name: etcdbackupconfigs.kubermatic.k8c.io
 spec:
   group: kubermatic.k8c.io

--- a/crd/k8c.io/kubermatic.k8c.io_etcdrestores.yaml
+++ b/crd/k8c.io/kubermatic.k8c.io_etcdrestores.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.10.0
+    kubermatic.k8c.io/location: seed
   name: etcdrestores.kubermatic.k8c.io
 spec:
   group: kubermatic.k8c.io

--- a/crd/k8c.io/kubermatic.k8c.io_externalclusters.yaml
+++ b/crd/k8c.io/kubermatic.k8c.io_externalclusters.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.10.0
+    kubermatic.k8c.io/location: master
   name: externalclusters.kubermatic.k8c.io
 spec:
   group: kubermatic.k8c.io

--- a/crd/k8c.io/kubermatic.k8c.io_groupprojectbindings.yaml
+++ b/crd/k8c.io/kubermatic.k8c.io_groupprojectbindings.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.10.0
+    kubermatic.k8c.io/location: master
   name: groupprojectbindings.kubermatic.k8c.io
 spec:
   group: kubermatic.k8c.io

--- a/crd/k8c.io/kubermatic.k8c.io_ipamallocations.yaml
+++ b/crd/k8c.io/kubermatic.k8c.io_ipamallocations.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.10.0
+    kubermatic.k8c.io/location: master
   name: ipamallocations.kubermatic.k8c.io
 spec:
   group: kubermatic.k8c.io

--- a/crd/k8c.io/kubermatic.k8c.io_ipampools.yaml
+++ b/crd/k8c.io/kubermatic.k8c.io_ipampools.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.10.0
+    kubermatic.k8c.io/location: master
   name: ipampools.kubermatic.k8c.io
 spec:
   group: kubermatic.k8c.io

--- a/crd/k8c.io/kubermatic.k8c.io_kubermaticconfigurations.yaml
+++ b/crd/k8c.io/kubermatic.k8c.io_kubermaticconfigurations.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.10.0
+    kubermatic.k8c.io/location: master,seed
   name: kubermaticconfigurations.kubermatic.k8c.io
 spec:
   group: kubermatic.k8c.io

--- a/crd/k8c.io/kubermatic.k8c.io_kubermaticsettings.yaml
+++ b/crd/k8c.io/kubermatic.k8c.io_kubermaticsettings.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.10.0
+    kubermatic.k8c.io/location: master
   name: kubermaticsettings.kubermatic.k8c.io
 spec:
   group: kubermatic.k8c.io

--- a/crd/k8c.io/kubermatic.k8c.io_mlaadminsettings.yaml
+++ b/crd/k8c.io/kubermatic.k8c.io_mlaadminsettings.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.10.0
+    kubermatic.k8c.io/location: seed
   name: mlaadminsettings.kubermatic.k8c.io
 spec:
   group: kubermatic.k8c.io

--- a/crd/k8c.io/kubermatic.k8c.io_presets.yaml
+++ b/crd/k8c.io/kubermatic.k8c.io_presets.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.10.0
+    kubermatic.k8c.io/location: master,seed
   name: presets.kubermatic.k8c.io
 spec:
   group: kubermatic.k8c.io

--- a/crd/k8c.io/kubermatic.k8c.io_projects.yaml
+++ b/crd/k8c.io/kubermatic.k8c.io_projects.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.10.0
+    kubermatic.k8c.io/location: master,seed
   name: projects.kubermatic.k8c.io
 spec:
   group: kubermatic.k8c.io

--- a/crd/k8c.io/kubermatic.k8c.io_resourcequotas.yaml
+++ b/crd/k8c.io/kubermatic.k8c.io_resourcequotas.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.10.0
+    kubermatic.k8c.io/location: master
   name: resourcequotas.kubermatic.k8c.io
 spec:
   group: kubermatic.k8c.io

--- a/crd/k8c.io/kubermatic.k8c.io_rulegroups.yaml
+++ b/crd/k8c.io/kubermatic.k8c.io_rulegroups.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.10.0
+    kubermatic.k8c.io/location: master
   name: rulegroups.kubermatic.k8c.io
 spec:
   group: kubermatic.k8c.io

--- a/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
+++ b/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.10.0
+    kubermatic.k8c.io/location: master,seed
   name: seeds.kubermatic.k8c.io
 spec:
   group: kubermatic.k8c.io

--- a/crd/k8c.io/kubermatic.k8c.io_userprojectbindings.yaml
+++ b/crd/k8c.io/kubermatic.k8c.io_userprojectbindings.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.10.0
+    kubermatic.k8c.io/location: master,seed
   name: userprojectbindings.kubermatic.k8c.io
 spec:
   group: kubermatic.k8c.io

--- a/crd/k8c.io/kubermatic.k8c.io_users.yaml
+++ b/crd/k8c.io/kubermatic.k8c.io_users.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.10.0
+    kubermatic.k8c.io/location: master,seed
   name: users.kubermatic.k8c.io
 spec:
   group: kubermatic.k8c.io

--- a/crd/k8c.io/kubermatic.k8c.io_usersshkeys.yaml
+++ b/crd/k8c.io/kubermatic.k8c.io_usersshkeys.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.10.0
+    kubermatic.k8c.io/location: master
   name: usersshkeys.kubermatic.k8c.io
 spec:
   group: kubermatic.k8c.io

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -37,3 +37,57 @@ for f in $CRD_DIR/*.yaml; do
   cat "$f.bak" >> "$f"
   rm "$f.bak"
 done
+
+annotation="kubermatic.k8c.io/location"
+locationMap='{
+  "applicationdefinitions.apps.kubermatic.k8c.io": "master,seed",
+  "applicationinstallations.apps.kubermatic.k8c.io": "usercluster",
+  "addonconfigs.kubermatic.k8c.io": "master",
+  "addons.kubermatic.k8c.io": "seed",
+  "admissionplugins.kubermatic.k8c.io": "master",
+  "alertmanagers.kubermatic.k8c.io": "seed",
+  "allowedregistries.kubermatic.k8c.io": "master",
+  "clusters.kubermatic.k8c.io": "seed",
+  "clustertemplateinstances.kubermatic.k8c.io": "seed",
+  "clustertemplates.kubermatic.k8c.io": "master,seed",
+  "constraints.kubermatic.k8c.io": "master,seed",
+  "constrainttemplates.kubermatic.k8c.io": "master,seed",
+  "customoperatingsystemprofiles.operatingsystemmanager.k8c.io": "seed",
+  "etcdbackupconfigs.kubermatic.k8c.io": "seed",
+  "etcdrestores.kubermatic.k8c.io": "seed",
+  "externalclusters.kubermatic.k8c.io": "master",
+  "groupprojectbindings.kubermatic.k8c.io": "master",
+  "ipamallocations.kubermatic.k8c.io": "master",
+  "ipampools.kubermatic.k8c.io": "master",
+  "kubermaticconfigurations.kubermatic.k8c.io": "master,seed",
+  "kubermaticsettings.kubermatic.k8c.io": "master",
+  "mlaadminsettings.kubermatic.k8c.io": "seed",
+  "presets.kubermatic.k8c.io": "master,seed",
+  "projects.kubermatic.k8c.io": "master,seed",
+  "resourcequotas.kubermatic.k8c.io": "master",
+  "rulegroups.kubermatic.k8c.io": "master",
+  "seeds.kubermatic.k8c.io": "master,seed",
+  "userprojectbindings.kubermatic.k8c.io": "master,seed",
+  "usersshkeys.kubermatic.k8c.io": "master",
+  "users.kubermatic.k8c.io": "master,seed"
+}'
+
+failure=false
+echo "Annotating CRDs"
+
+for filename in $CRD_DIR/*.yaml; do
+  crdName="$(yq '.metadata.name' "$filename")"
+  location="$(echo "$locationMap" | jq -rc --arg key "$crdName" '.[$key]')"
+
+  if [ -z "$location" ]; then
+    echodate "Error: No location defined for CRD $crdName"
+    failure=true
+    continue
+  fi
+
+  yq --inplace ".metadata.annotations.\"$annotation\" = \"$location\"" "$filename"
+done
+
+if $failure; then
+  exit 1
+fi


### PR DESCRIPTION
**What this PR does / why we need it**:
At first I did not copy the labeling mechanism, as I thought the api repo was only for KKP 3.x. But we want to migrate KKP 2.x already, so here is the necessary labeling.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
