### PR TITLE
sync with KKP @ 67e5523416

### DIFF
--- a/crd/k8c.io/kubermatic.k8c.io_kubermaticconfigurations.yaml
+++ b/crd/k8c.io/kubermatic.k8c.io_kubermaticconfigurations.yaml
@@ -331,6 +331,9 @@ spec:
                     dockerTag:
                       description: DockerTag is used to overwrite the dashboard Docker image tag and is only for development purposes. This field must not be set in production environments. ---
                       type: string
+                    dockerTagSuffix:
+                      description: DockerTagSuffix is appended to the KKP version used for referring to the custom dashboard image. If left empty, either the `DockerTag` if specified or the original dashboard Docker image tag will be used. With DockerTagSuffix the tag becomes <KKP_VERSION:SUFFIX> i.e. "v2.15.0-SUFFIX".
+                      type: string
                     replicas:
                       description: Replicas sets the number of pod replicas for the UI deployment.
                       format: int32

--- a/pkg/apis/kubermatic/v1/configuration.go
+++ b/pkg/apis/kubermatic/v1/configuration.go
@@ -153,6 +153,10 @@ type KubermaticUIConfiguration struct {
 	//nolint:staticcheck
 	//lint:ignore SA5008 omitgenyaml is used by the example-yaml-generator
 	DockerTag string `json:"dockerTag,omitempty,omitgenyaml"`
+	// DockerTagSuffix is appended to the KKP version used for referring to the custom dashboard image.
+	// If left empty, either the `DockerTag` if specified or the original dashboard Docker image tag will be used.
+	// With DockerTagSuffix the tag becomes <KKP_VERSION:SUFFIX> i.e. "v2.15.0-SUFFIX".
+	DockerTagSuffix string `json:"dockerTagSuffix,omitempty"`
 	// Config sets flags for various dashboard features.
 	Config string `json:"config,omitempty"`
 	// Resources describes the requested and maximum allowed CPU/memory usage.


### PR DESCRIPTION
**What this PR does / why we need it**:
Just so we have a known point in time at which we extracted the APIs.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
