### PR TITLE
introduce kubermaticconfig.spec.usercluster.basedomain

### DIFF
--- a/crd/community/kubermatic.k8c.io_kubermaticconfigurations.yaml
+++ b/crd/community/kubermatic.k8c.io_kubermaticconfigurations.yaml
@@ -1540,6 +1540,9 @@ spec:
                       description: APIServerReplicas configures the replica count for the API-Server deployment inside user clusters.
                       format: int32
                       type: integer
+                    baseDomain:
+                      description: This configures the base domain for all userclusters. Each usercluster will get a subdomain (named <clustername>.<basedomain>) to allow access to the cluster's controlplane. This domain should be different from the main ingress (which makes the KKP dashboard available), as cluster names might collide with other, well-known names and could interfere with the dashboard. If your dashboard is using "example.com", you could configure the usercluster base domain as "clusters.example.com".
+                      type: string
                     defaultTemplate:
                       description: DefaultCTemplate is the name of a cluster template that is used to default a new user cluster.
                       type: string
@@ -1680,6 +1683,8 @@ spec:
                           description: HelmRepository specifies OCI repository containing Helm charts of system Applications.
                           type: string
                       type: object
+                  required:
+                    - baseDomain
                   type: object
                 versions:
                   description: Versions configures the available and default Kubernetes versions and updates.

--- a/crd/enterprise/seed/kubermatic.k8c.io_kubermaticconfigurations.yaml
+++ b/crd/enterprise/seed/kubermatic.k8c.io_kubermaticconfigurations.yaml
@@ -1540,6 +1540,9 @@ spec:
                       description: APIServerReplicas configures the replica count for the API-Server deployment inside user clusters.
                       format: int32
                       type: integer
+                    baseDomain:
+                      description: This configures the base domain for all userclusters. Each usercluster will get a subdomain (named <clustername>.<basedomain>) to allow access to the cluster's controlplane. This domain should be different from the main ingress (which makes the KKP dashboard available), as cluster names might collide with other, well-known names and could interfere with the dashboard. If your dashboard is using "example.com", you could configure the usercluster base domain as "clusters.example.com".
+                      type: string
                     defaultTemplate:
                       description: DefaultCTemplate is the name of a cluster template that is used to default a new user cluster.
                       type: string
@@ -1680,6 +1683,8 @@ spec:
                           description: HelmRepository specifies OCI repository containing Helm charts of system Applications.
                           type: string
                       type: object
+                  required:
+                    - baseDomain
                   type: object
                 versions:
                   description: Versions configures the available and default Kubernetes versions and updates.

--- a/pkg/apis/kubermatic/v1/configuration.go
+++ b/pkg/apis/kubermatic/v1/configuration.go
@@ -228,6 +228,13 @@ type KubermaticWebhookConfiguration struct {
 
 // KubermaticUserClusterConfiguration controls various aspects of the user-created clusters.
 type KubermaticUserClusterConfiguration struct {
+	// This configures the base domain for all userclusters. Each usercluster will get a subdomain
+	// (named <clustername>.<basedomain>) to allow access to the cluster's controlplane. This
+	// domain should be different from the main ingress (which makes the KKP dashboard available),
+	// as cluster names might collide with other, well-known names and could interfere with the
+	// dashboard. If your dashboard is using "example.com", you could configure the usercluster
+	// base domain as "clusters.example.com".
+	BaseDomain string `json:"baseDomain"`
 	// DefaultCTemplate is the name of a cluster template that is used to default a new user cluster.
 	DefaultTemplate string `json:"defaultTemplate,omitempty"`
 	// KubermaticDockerRepository is the repository containing the Kubermatic user-cluster-controller-manager image.


### PR DESCRIPTION
**What this PR does / why we need it**:
In KKP 2, cluster domains were formed à la `<clustername>.<seedname>.<ingressdomain>`, but in KKP 3 there is no more Seed object. I would suggest it still makes sense to separate user cluster domains from the "ingress domains", otherwise a cluster named "www" might get the URL `www.<ingressdomain>`, which could cause complications.

This PR therefore adds an additional field to the UserCluster configuration, allowing the admin to explicitly set the base domain.

**Does this PR introduce a user-facing change?**:
```release-note
`KubermaticConfiguration.spec.userCluster.baseDomain` takes the role of what was previously the seed name + the general base domain
```
